### PR TITLE
Add storage-container status

### DIFF
--- a/com/packetdigital/storagecontainer/20993.StorageContainerStatus.uavcan
+++ b/com/packetdigital/storagecontainer/20993.StorageContainerStatus.uavcan
@@ -1,0 +1,7 @@
+#
+# The current status of the storage-container
+#
+
+uint8 STORAGE_CONTAINER_STATUS_NORMAL      = 0 # OK to charge/discharge/heat the battery
+uint8 STORAGE_CONTAINER_STATUS_FAULT       = 1 # All battery operations should halt immediately
+uint8 storage_container_status


### PR DESCRIPTION
My current plan is:

- The storage-container will send this message 5 times per second.
- When the charger receives the first message, it will register the presence of the storage-contianer on the CAN bus.
- After a storage-container has been registered, if the charger stops receiving storage container status messages, it will stop charging that specific bay.
- If `storage_container_status` is `STORAGE_CONTAINER_STATUS_FAULT`, then all charge/discharge/heater operations will be terminated on all bays.
- Charge/discharge/heater operations will be re-enabled after the storage-container broadcasts a status message with `STORAGE_CONTAINER_STATUS_NORMAL`.