### PR TITLE
Add Temperature and More Faults to StorageContainerStatus

### DIFF
--- a/com/packetdigital/storagecontainer/20993.StorageContainerStatus.uavcan
+++ b/com/packetdigital/storagecontainer/20993.StorageContainerStatus.uavcan
@@ -2,6 +2,17 @@
 # The current status of the storage-container
 #
 
-uint8 STORAGE_CONTAINER_STATUS_NORMAL      = 0 # OK to charge/discharge/heat the battery
-uint8 STORAGE_CONTAINER_STATUS_FAULT       = 1 # All battery operations should halt immediately
+
+#
+# If the status is not NORMAL, it is NOT safe to charge or discharge the battery.
+#
+uint8 STORAGE_CONTAINER_STATUS_NORMAL           = 0 # OK to charge/discharge/heat the battery
+uint8 STORAGE_CONTAINER_STATUS_FAULT            = 1 # Generic fault
+uint8 STORAGE_CONTAINER_STATUS_FAULT_OVERTEMP   = 2 # Temperature exceeded maximum safe threshold
+uint8 STORAGE_CONTAINER_STATUS_FAULT_GAS_SENSOR = 3 # Gas sensor has stopped responding
 uint8 storage_container_status
+
+#
+# Temperature inside the storage container
+#
+float16 temperature # [Celsius]


### PR DESCRIPTION
During board-bring-up testing of the Storage Container PCBA, Isaac and I thought `StorageContainerStatus` would be much more useful if it reported the present temperature.  We also wanted the status message to tell _why_ there was a fault.  This will make troubleshooting faster.

If this gets merged, I will then update storage-container and charger firmware to use this updated message definition.

p.s. there is an issue with github CI, but not due to these changes.