### PR TITLE
Change gas sensor faults in StorageContainerStatus

### DIFF
--- a/com/packetdigital/storagecontainer/20993.StorageContainerStatus.uavcan
+++ b/com/packetdigital/storagecontainer/20993.StorageContainerStatus.uavcan
@@ -17,3 +17,8 @@ uint8 storage_container_status
 # Temperature inside the storage container
 #
 float16 temperature # [Celsius]
+
+#
+# Output signal from the gas sensor
+#
+float16 gas_sensor_output_voltage # [Volts]

--- a/com/packetdigital/storagecontainer/20993.StorageContainerStatus.uavcan
+++ b/com/packetdigital/storagecontainer/20993.StorageContainerStatus.uavcan
@@ -6,10 +6,11 @@
 #
 # If the status is not NORMAL, it is NOT safe to charge or discharge the battery.
 #
-uint8 STORAGE_CONTAINER_STATUS_NORMAL           = 0 # OK to charge/discharge/heat the battery
-uint8 STORAGE_CONTAINER_STATUS_FAULT            = 1 # Generic fault
-uint8 STORAGE_CONTAINER_STATUS_FAULT_OVERTEMP   = 2 # Temperature exceeded maximum safe threshold
-uint8 STORAGE_CONTAINER_STATUS_FAULT_GAS_SENSOR = 3 # Gas sensor has stopped responding
+uint8 STORAGE_CONTAINER_STATUS_NORMAL               = 0 # OK to charge/discharge/heat the battery
+uint8 STORAGE_CONTAINER_STATUS_FAULT                = 1 # Generic fault
+uint8 STORAGE_CONTAINER_STATUS_FAULT_OVERTEMP       = 2 # Temperature exceeded maximum safe threshold
+uint8 STORAGE_CONTAINER_STATUS_FAULT_SENSOR_ERROR   = 3 # Gas sensor itself has malfunctioned
+uint8 STORAGE_CONTAINER_STATUS_FAULT_GAS_DETECTED   = 4 # Battery leak detected
 uint8 storage_container_status
 
 #


### PR DESCRIPTION
This is to support the new output specs from the gas sensor we use in the storage container.